### PR TITLE
AugSynth Predictor Optimization & P-Value Fixes

### DIFF
--- a/pysyncon/augsynth.py
+++ b/pysyncon/augsynth.py
@@ -53,9 +53,9 @@ class AugSynth(BaseSynth, VanillaOptimMixin):
         else:
             self.lambda_ = lambda_
 
-        n_r, _ = X0.shape
+        n_r, _ = X0_stacked.shape
         V_mat = np.diag(np.full(n_r, 1 / n_r))
-        W, _ = self.w_optimize(V_mat=V_mat, X0=X0.to_numpy(), X1=X1.to_numpy())
+        W, _ = self.w_optimize(V_mat=V_mat, X0=X0_stacked.to_numpy(), X1=X1_stacked.to_numpy())
 
         W_ridge = self.solve_ridge(
             X1_stacked.to_numpy(), X0_stacked.to_numpy(), W, self.lambda_

--- a/pysyncon/utils.py
+++ b/pysyncon/utils.py
@@ -346,6 +346,5 @@ class PlaceboTest:
         t0, _ = self.gaps.loc[:treatment_time].shape
 
         rmspe = (num / (t - t0)) / (denom / t0)
-        return sum(
-            rmspe.drop(index=self.treated_gap.name) >= rmspe.loc[self.treated_gap.name]
-        ) / len(rmspe)
+        rank = 1 + sum(rmspe.drop(index=self.treated_gap.name) >= rmspe.loc[self.treated_gap.name])
+        return rank / len(rmspe)


### PR DESCRIPTION
Augsynth was not using other predictors besides the outcome variable in the weights optimization. The ridge regression is not enough to adjust the weights based on other (or special) predictors. Including the predictors in the initial weights optimization ensures the treatment and synthetic variable is almost equal in all predictors in the pre-treatment period, where possible.