### PR TITLE
Add stopping condition for while loop

### DIFF
--- a/pysyncon/robust.py
+++ b/pysyncon/robust.py
@@ -102,9 +102,10 @@ class RobustSynth(BaseSynth):
         if not threshold and not sv_count:
             raise ValueError("One of `threshold` or `sv_count` must be supplied.")
         u, s, v = np.linalg.svd(Y)
+        s_shape = s.shape[0] - 1
         if threshold:
             idx = 0
-            while s[idx] > threshold:
+            while s[idx] > threshold and idx < s_shape:
                 idx += 1
         else:
             idx = sv_count


### PR DESCRIPTION
The while loop in robust.py assumes that we've specified a high enough threshold to end. However, if the threshold is low enough, we will continue looping until we try to access an element that is beyond the size of s, creating an error. We have now added a stopping condition to that.